### PR TITLE
fix: wrong field name in TrainerInfo

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -203,33 +203,33 @@ func TestUpdateTrainerHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-// func TestFilter(t *testing.T) {
-// 	r := SetUpRouter()
-// 	routes.AuthRoute(r)
-// 	routes.ProtectedRoute(r)
-// 	user := User{
-// 		Username: "test01",
-// 		Password: "password01",
-// 	}
-// 	update := FilterTrainer{
-// 		Specialty: []string{"yoga"},
-// 		Limit:     1,
-// 	}
-// 	jsonValue, _ := json.Marshal(user)
-// 	loginReq, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(jsonValue))
-// 	w := httptest.NewRecorder()
-// 	r.ServeHTTP(w, loginReq)
+func TestFilter(t *testing.T) {
+	r := SetUpRouter()
+	routes.AuthRoute(r)
+	routes.ProtectedRoute(r)
+	user := User{
+		Username: "test01",
+		Password: "password01",
+	}
+	update := FilterTrainer{
+		Specialty: []string{"yoga"},
+		Limit:     1,
+	}
+	jsonValue, _ := json.Marshal(user)
+	loginReq, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(jsonValue))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, loginReq)
 
-// 	var response responses.LoginResponse
-// 	err := json.Unmarshal(w.Body.Bytes(), &response)
-// 	if err != nil {
-// 		t.Fatal("Failed to parse response: ", err)
-// 	}
-// 	jwt := response.Token
-// 	jsonValue, _ = json.Marshal(update)
-// 	userReq, _ := http.NewRequest("POST", "/protected/filter-trainer", bytes.NewBuffer(jsonValue))
-// 	userReq.Header.Set("Authorization", "Bearer "+jwt)
-// 	w = httptest.NewRecorder()
-// 	r.ServeHTTP(w, userReq)
-// 	assert.Equal(t, http.StatusOK, w.Code)
-// }
+	var response responses.LoginResponse
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	if err != nil {
+		t.Fatal("Failed to parse response: ", err)
+	}
+	jwt := response.Token
+	jsonValue, _ = json.Marshal(update)
+	userReq, _ := http.NewRequest("POST", "/protected/filter-trainer", bytes.NewBuffer(jsonValue))
+	userReq.Header.Set("Authorization", "Bearer "+jwt)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, userReq)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/models/auth_model.go
+++ b/models/auth_model.go
@@ -15,11 +15,11 @@ import (
 var userCollection *mongo.Collection = configs.GetCollection(configs.DB, "users")
 
 type TrainerInfo struct {
-	Specialty      []string `bson:"specialty"`
-	CertificateURL string   `bson:"certificateUrl"`
-	TraineeCount   int32    `bson:"traineeCount"`
-	Fee            int32    `bson:"fee"`
-	Rating         float64  `bson:"rating"`
+	Specialty      []string `bson:"specialty" json:"specialty"`
+	CertificateURL string   `bson:"certificateUrl" json:"certificateUrl"`
+	TraineeCount   int32    `bson:"traineeCount" json:"traineeCount"`
+	Fee            int32    `bson:"fee" json:"fee"`
+	Rating         float64  `bson:"rating" json:"rating"`
 }
 type User struct {
 	Username       string      `bson:"username"`


### PR DESCRIPTION
- `json` tags is missing from TrainerInfo causing the return response to be incorrect.
- It is added, the response and the test now works.